### PR TITLE
fix: redirect to longUrl pg

### DIFF
--- a/client/src/components/retrieve/Retrieve.jsx
+++ b/client/src/components/retrieve/Retrieve.jsx
@@ -11,11 +11,13 @@ const Retrieve = () => {
   useEffect(() => {
     setRetrieveUrl(retrieveUrl)
     console.log(retrieveUrl)
-    window.location.href=`${retrieveUrl}`
   },[retrieveUrl])
 
     axios.get(`http://localhost:8000/shorten/${param.shortCode}`)
-    .then((res) => setRetrieveUrl(res.data))
+    .then((res) => {
+      setRetrieveUrl(res.data)
+      window.location.href=retrieveUrl
+    })
     .catch((e) => console.log(e.message))
     //api call
     //until result found => display container


### PR DESCRIPTION
the longUrl variable is supposed to be assigned itself, but it was assigned using template strings which caused redirection error